### PR TITLE
Ajout fichiers pour LNX101 et CIP101.

### DIFF
--- a/ecole/config.yaml
+++ b/ecole/config.yaml
@@ -53,7 +53,14 @@ profile::accounts::skel_archives:
     source: https://github.com/calculquebec/.cache/releases/download/v1/cache-v1.zip
   - filename: jupyter.zip
     source: https://github.com/calculquebec/jupyterlab-settings/releases/download/v1.0.1/jupyter-v1.0.1.zip
+  - filename: main.zip
+    source: https://github.com/calculquebec/cip101-exercices/archive/refs/heads/main.zip
+  - filename: shell-lesson-data.zip
+    source: https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip
 
+formation_extra::stripped_skel_archives:
+  - filename: cip101_skel_extra.tar.gz
+    source: https://github.com/calculquebec/formation_skels/archive/refs/heads/cip101.tar.gz
 
 cron::job:
   spawn_cpu_nodes:


### PR DESCRIPTION
Je voulais tester pour `monordi`. Si c'est possible d'ajouter tout de suite les fichiers pour LNX101 et CIP101. Sinon je vais attendre qu'on ajoute pour tout le monde en même temps. 