### PR TITLE
Ecole helene

### DIFF
--- a/ecole/config.yaml
+++ b/ecole/config.yaml
@@ -58,10 +58,6 @@ profile::accounts::skel_archives:
   - filename: shell-lesson-data.zip
     source: https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip
 
-formation_extra::stripped_skel_archives:
-  - filename: cip101_skel_extra.tar.gz
-    source: https://github.com/calculquebec/formation_skels/archive/refs/heads/cip101.tar.gz
-
 cron::job:
   spawn_cpu_nodes:
     command: "/opt/software/slurm/bin/scontrol update node=nodecpupool[1-15] state=power_up"

--- a/ecole/config.yaml
+++ b/ecole/config.yaml
@@ -53,7 +53,14 @@ profile::accounts::skel_archives:
     source: https://github.com/calculquebec/.cache/releases/download/v1/cache-v1.zip
   - filename: jupyter.zip
     source: https://github.com/calculquebec/jupyterlab-settings/releases/download/v1.0.1/jupyter-v1.0.1.zip
+  - filename: main.zip
+    source: https://github.com/calculquebec/cip101-exercices/archive/refs/heads/main.zip
+  - filename: shell-lesson-data.zip
+    source: https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip
 
+formation_extra::stripped_skel_archives:
+  - filename: cip101_skel_extra.tar.gz
+    source: https://github.com/calculquebec/formation_skels/archive/refs/heads/cip101.tar.gz
 
 cron::job:
   spawn_cpu_nodes:


### PR DESCRIPTION
Enlevé cip101_skel_extra puisque cela ne peut pas être appliqué à la grappe de l'école. Cela est supposé afficher`monordi ` au lieu du noeud de connection de la grappe. 
source: https://github.com/calculquebec/formation_skels/archive/refs/heads/cip101.tar.gz